### PR TITLE
fix: handle new userinfo endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ node_js:
   - "0.12"
   - "0.10"
   - "0.8"
-  - "0.6"
 
 
 before_install:

--- a/README.md
+++ b/README.md
@@ -85,6 +85,27 @@ app.get('/auth/google/callback',
   });
   ```
 
+#### Google Plus API Deprecation
+
+The default for `passport-google-oauth2` is to use the Google+ People API to
+get the profile information for the user signing in.  With this API being
+removed in early 2019 you should look towards using the OAuth 2 User Info
+endpoint instead.  You can switch to this endpoint using this configuration
+option.
+
+```javascript
+new GoogleStrategy({
+  clientID: GOOGLE_CLIENT_ID,
+  clientSecret: GOOGLE_CLIENT_SECRET,
+  callbackURL: "http://www.example.com/auth/google/callback",
+  // This option tells the strategy to use the userinfo endpoint instead
+  userProfileURL: "https://www.googleapis.com/oauth2/v2/userinfo",
+}
+```
+
+The structure of the `profile` object will be the same but you may get
+less profile information than you did before.
+
 ## Examples
 
 Developers using the popular [Express](http://expressjs.com/) web framework can

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ new GoogleStrategy({
   clientSecret: GOOGLE_CLIENT_SECRET,
   callbackURL: "http://www.example.com/auth/google/callback",
   // This option tells the strategy to use the userinfo endpoint instead
-  userProfileURL: "https://www.googleapis.com/oauth2/v2/userinfo",
+  userProfileURL: "https://www.googleapis.com/oauth2/v3/userinfo",
 }
 ```
 

--- a/lib/profile/openid.js
+++ b/lib/profile/openid.js
@@ -23,14 +23,14 @@ exports.parse = function(json) {
   }
   
   var profile = {};
-  profile.id = json.sub;
+  profile.id = json.sub || json.id;
   profile.displayName = json.name;
   if (json.family_name || json.given_name) {
     profile.name = { familyName: json.family_name,
                      givenName: json.given_name };
   }
   if (json.email) {
-    profile.emails = [ { value: json.email, verified: json.email_verified } ];
+    profile.emails = [ { value: json.email, verified: json.email_verified || json.verified_email } ];
   }
   if (json.picture) {
     profile.photos = [{ value: json.picture }];

--- a/test/fixtures/userinfo/userinfo-with-id.json
+++ b/test/fixtures/userinfo/userinfo-with-id.json
@@ -1,0 +1,8 @@
+{
+  "id": "111111111111111111112",
+  "name": "",
+  "given_name": "",
+  "family_name": "",
+  "picture": "https://lh3.googleusercontent.com/-XxXXxxXxXXX/AAAAAAAAAAI/AAAAAAAAAAA/0000xxxxx0X/photo.jpg"
+}
+

--- a/test/fixtures/userinfo/userinfo-with-verified-email.json
+++ b/test/fixtures/userinfo/userinfo-with-verified-email.json
@@ -1,0 +1,10 @@
+{
+  "sub": "111111111111111111111",
+  "name": "Jared Hanson",
+  "given_name": "Jared",
+  "family_name": "Hanson",
+  "picture": "https://lh3.googleusercontent.com/-XxXXxxXxXXX/AAAAAAAAAAI/AAAAAAAAAAA/0000xxxxx0X/photo.jpg",
+  "email": "example@gmail.com",
+  "verified_email": true,
+  "locale": "en"
+}

--- a/test/profile/openid.test.js
+++ b/test/profile/openid.test.js
@@ -70,6 +70,40 @@ describe('OpenIDProfile.parse', function() {
       expect(profile.photos[0].value).to.equal('https://lh3.googleusercontent.com/-XxXXxxXxXXX/AAAAAAAAAAI/AAAAAAAAAAA/0000xxxxx0X/photo.jpg');
     });
   });
+
+  describe('profile with new "id" style', function() {
+    var profile;
+
+    before(function(done) {
+      fs.readFile('test/fixtures/userinfo/userinfo-with-id.json', 'utf8', function(err, data) {
+        if (err) { return done(err); }
+        profile = Profile.parse(data);
+        done();
+      });
+    });
+
+    it('should parse profile', function() {
+      expect(profile.id).to.equal('111111111111111111112');
+    });
+  });
+
+  describe('profile with new "verified_email" style', function() {
+    var profile;
+
+    before(function(done) {
+      fs.readFile('test/fixtures/userinfo/userinfo-with-verified-email.json', 'utf8', function(err, data) {
+        if (err) { return done(err); }
+        profile = Profile.parse(data);
+        done();
+      });
+    });
+
+    it('should parse profile', function() {
+      expect(profile.emails).to.have.length(1);
+      expect(profile.emails[0].value).to.equal('example@gmail.com');
+      expect(profile.emails[0].verified).to.equal(true);
+    });
+  });
   
   describe('profile without picture attribute', function() {
     var profile;


### PR DESCRIPTION
Google is deprecating and completely removing the Google Plus APIs early next year.  The easiest migration path for users of this module is to provide `userProfileURL: 'https://www.googleapis.com/oauth2/v3/userinfo',` in the strategy options (use the oauth userinfo endpoint instead of G+).  This mostly works in its current state.

However there are some issues with the openid parser on this endpoint, this PR fixes several of those.

* `email_verified` can now be `verified_email`
* `sub` is now `id`

- [x] I have read the [CONTRIBUTING](https://github.com/jaredhanson/passport-google-oauth2/blob/master/CONTRIBUTING.md) guidelines.
- [x] I have added test cases which verify the correct operation of this feature or patch.
- [x] I have added documentation pertaining to this feature or patch.
- [x] The automated test suite (`$ make test`) executes successfully.
- [x] The automated code linting (`$ make lint`) executes successfully.
