### PR TITLE
Replace Google+ Sign-In with Google Sign-In

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -51,7 +51,7 @@ function Strategy(options, verify) {
 
   OAuth2Strategy.call(this, options, verify);
   this.name = 'google';
-  this._userProfileURL = options.userProfileURL || 'https://www.googleapis.com/plus/v1/people/me';
+  this._userProfileURL = options.userProfileURL || 'https://www.googleapis.com/oauth2/v3/userinfo';
   
   var url = uri.parse(this._userProfileURL);
   if (url.pathname.indexOf('/userinfo') == (url.pathname.length - '/userinfo'.length)) {

--- a/test/strategy.profile.test.js
+++ b/test/strategy.profile.test.js
@@ -9,7 +9,8 @@ describe('Strategy#userProfile', function() {
   describe('fetched from Google+ API', function() {
     var strategy = new GoogleStrategy({
         clientID: 'ABC123',
-        clientSecret: 'secret'
+        clientSecret: 'secret',
+        userProfileURL: 'https://www.googleapis.com/plus/v1/people/me'
       }, function() {});
   
     strategy._oauth2.get = function(url, accessToken, callback) {
@@ -101,8 +102,7 @@ describe('Strategy#userProfile', function() {
   describe('fetched from OpenID Connect user info endpoint', function() {
     var strategy = new GoogleStrategy({
         clientID: 'ABC123',
-        clientSecret: 'secret',
-        userProfileURL: 'https://www.googleapis.com/oauth2/v3/userinfo'
+        clientSecret: 'secret'
       }, function() {});
   
     strategy._oauth2.get = function(url, accessToken, callback) {
@@ -148,7 +148,8 @@ describe('Strategy#userProfile', function() {
   describe('error caused by invalid token when using Google+ API', function() {
     var strategy = new GoogleStrategy({
         clientID: 'ABC123',
-        clientSecret: 'secret'
+        clientSecret: 'secret',
+        userProfileURL: 'https://www.googleapis.com/plus/v1/people/me'
       }, function() {});
     
     strategy._oauth2.get = function(url, accessToken, callback) {
@@ -179,7 +180,8 @@ describe('Strategy#userProfile', function() {
   describe('error caused by invalid token when using user info endpoint', function() {
     var strategy = new GoogleStrategy({
         clientID: 'ABC123',
-        clientSecret: 'secret'
+        clientSecret: 'secret',
+        userProfileURL: 'https://www.googleapis.com/plus/v1/people/me'
       }, function() {});
     
     strategy._oauth2.get = function(url, accessToken, callback) {


### PR DESCRIPTION
This PR replaces the use of Google+ people.get API with Google OpenID Connect userinfo endpoint, following the recommended migration path necessitated by the [Google+ API shutdown](https://developers.google.com/+/api-shutdown).