### PR TITLE
Support Google's documented "state" authorization parameter

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -147,6 +147,9 @@ Strategy.prototype.authorizationParams = function(options) {
   if (options.includeGrantedScopes) {
     params['include_granted_scopes'] = true;
   }
+  if (options.state) {
+    params['state'] = options.state;
+  }
   
   // https://developers.google.com/identity/protocols/OpenIDConnect
   if (options.display) {

--- a/test/strategy.test.js
+++ b/test/strategy.test.js
@@ -104,6 +104,32 @@ describe('Strategy', function() {
     });
   }); // authorization request with incremental authorization parameters
   
+  describe('authorization request with state parameters', function() {
+    var strategy = new GoogleStrategy({
+      clientID: 'ABC123',
+      clientSecret: 'secret'
+    }, function() {});
+    
+    
+    var url;
+  
+    before(function(done) {
+      chai.passport.use(strategy)
+        .redirect(function(u) {
+          url = u;
+          done();
+        })
+        .req(function(req) {
+          req.session = {};
+        })
+        .authenticate({ state: 'abc=123' });
+    });
+  
+    it('should be redirected', function() {
+      expect(url).to.equal('https://accounts.google.com/o/oauth2/v2/auth?state=abc%3D123&response_type=code&client_id=ABC123');
+    });
+  }); // authorization request with state parameters
+  
   describe('authorization request with Google Apps for Work parameters', function() {
     var strategy = new GoogleStrategy({
       clientID: 'ABC123',


### PR DESCRIPTION
[Google's OAuth2 Rest API](https://developers.google.com/identity/protocols/OAuth2WebServer#creatingclient) supports a parameter called **state**, as described in the docs:

> Specifies any string value that your application uses to maintain state between your authorization request and the authorization server's response. ... You can use this parameter for several purposes, such as directing the user to the correct resource in your application, sending nonces, and mitigating cross-site request forgery. 

I'm using it for two purposes – redirects and invite code. I have both of these pieces of state prior to Google Authentication, and after a user has successfully authed with google, I want to verify their invite code and redirect them to the page they were browsing before authenticating.

My temporary workaround is to extend this strategy in my own code with support for the `state` param:

```js
const googleAuthParamsOrig = GoogleStrategy.prototype.authorizationParams;
GoogleStrategy.prototype.authorizationParams = function(options: any) {
  const params = googleAuthParamsOrig.call(this, options);

  if (options.state) {
    params.state = options.state;
  }

  return params;
};
```

but it would be great to get it supported by default.

### Checklist

<!-- Place an `x` in the boxes that apply.  If you are unsure, please ask and -->
<!-- we will help. -->

- [X] I have read the [CONTRIBUTING](https://github.com/jaredhanson/passport-google-oauth2/blob/master/CONTRIBUTING.md) guidelines.
- [X] I have added test cases which verify the correct operation of this feature or patch.
- [X] I have added documentation pertaining to this feature or patch. **(many of the existing params are not documented in passport docs)**
- [X] The automated test suite (`$ make test`) executes successfully.
- [X] The automated code linting (`$ make lint`) executes successfully.
