### PR TITLE
Added how-to configure google optional parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,25 @@ app.get('/auth/google/callback',
   });
   ```
 
+In order to add Google-specific authorization parameters to the google authoriztion
+URI, the `passport.authenticate` middleware can be given the google options in the 
+2nd parameter like so:
+
+```javascript
+app.get('/auth/google/callback', 
+  passport.authenticate('google', { 
+    failureRedirect: '/login',
+    prompt: 'select-account',
+    hd: '',
+    loginHint: '',
+    accessType: '',
+  }),
+  function(req, res) {
+    // Successful authentication, redirect home.
+    res.redirect('/');
+  });
+  ```
+
 ## Examples
 
 Developers using the popular [Express](http://expressjs.com/) web framework can


### PR DESCRIPTION
This patch adds a couple lines in the README documenting how to configure google specific authorization params.

### Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/jaredhanson/passport-google-oauth2/blob/master/CONTRIBUTING.md) guidelines.
- [-] I have added test cases which verify the correct operation of this feature or patch.
- [x] I have added documentation pertaining to this feature or patch.
- [x] The automated test suite (`$ make test`) executes successfully.
- [-] The automated code linting (`$ make lint`) executes successfully.
