### PR TITLE
Remove note about 'hd' claim being undocumented

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -157,9 +157,6 @@ Strategy.prototype.authorizationParams = function(options) {
   
   // Google Apps for Work
   if (options.hostedDomain || options.hd) {
-    // This parameter is derived from Google's OAuth 1.0 endpoint, and (although
-    // undocumented) is supported by Google's OAuth 2.0 endpoint was well.
-    //   https://developers.google.com/accounts/docs/OAuth_ref
     params['hd'] = options.hostedDomain || options.hd;
   }
   


### PR DESCRIPTION
Because it's not anymore: https://developers.google.com/identity/sign-in/web/backend-auth